### PR TITLE
Fix problem with google font spaces.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -55,7 +55,7 @@
     {{/* set default values if no custom ones are defined */}}
     {{ $text := or .Site.Params.font.text "Roboto" }}
     {{ $code := or .Site.Params.font.code "Roboto Mono" }}
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family={{ $text }}:400,700|{{ replace  $code " " "+" }}">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family={{ $text }}:400,700|{{ replace  $code " " "+" | safeURL }}">
     <style>
       body, input {
         font-family: '{{ $text }}', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
If using a non default google font the space was being replaced with %2b which google does not understand. Telling hugo that this is a safe url results in &#43; which allows the usage of non default subfonts.
